### PR TITLE
WN-0006: dimensions should be allowed with scalar lens shortcut

### DIFF
--- a/wns/WN-0006/WN-0006.md
+++ b/wns/WN-0006/WN-0006.md
@@ -3,6 +3,7 @@
 - **Status**: *Acccepted* / *Experimental* (parts) 
 - **Discussions-To:**  https://github.com/malloydata/malloy/discussions/1425, slack, gchat
 - **Author:** lloyd tabb, Chris Swenson, Michael Toy
+- **Experimental Flags:** `scalar_lenses` (this is only for dimension/measures being used with `+`; view lenses are not experimental)
 
 In the current Malloy language, the only use of a view as of a query refinement can be the first segment.  For a number of reasons we should allow views to be used any in order.  
 
@@ -40,12 +41,15 @@ The ouptut columns
 > nickname, flight_count, total_distance, total_seats_flown
 
 
-## Aggregates have a shorthanded (Experimental)
+## Dimensions and Measures have a shorthanded (Experimental)
 
-You can use the name of an aggregate and it is assumed mean a view containing a single aggregate
+You can use the name of a dimension or measure and it is assumed mean a view containing a single `group_by` or `aggregate` respectively.
+
+Dotted names are allowed when using this shortcut
 
 ```
-run: flights -> {group_by: carriers.nickname} + flights_lens + origin_count
+##! experimental { scalar_lenses }
+run: flights -> carriers.nickname + flights_lens + origin_count
 ```
 
 means the same thing as 


### PR DESCRIPTION
Modified WN to say that both dimensions and measures should be allowed with the lens shortcut experiment.